### PR TITLE
pathplanner: 2024.1.4 -> 2024.1.7

### DIFF
--- a/pkgs/pathplanner/pubspec.lock.json
+++ b/pkgs/pathplanner/pubspec.lock.json
@@ -24,11 +24,11 @@
       "dependency": "transitive",
       "description": {
         "name": "archive",
-        "sha256": "7b875fd4a20b165a3084bd2d210439b22ebc653f21cea4842729c0c30c82596b",
+        "sha256": "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.4.9"
+      "version": "3.4.10"
     },
     "args": {
       "dependency": "transitive",
@@ -104,21 +104,21 @@
       "dependency": "direct dev",
       "description": {
         "name": "build_runner",
-        "sha256": "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b",
+        "sha256": "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.7"
+      "version": "2.4.8"
     },
     "build_runner_core": {
       "dependency": "transitive",
       "description": {
         "name": "build_runner_core",
-        "sha256": "c9e32d21dd6626b5c163d48b037ce906bbe428bc23ab77bcd77bb21e593b6185",
+        "sha256": "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.2.11"
+      "version": "7.3.0"
     },
     "built_collection": {
       "dependency": "transitive",
@@ -134,21 +134,21 @@
       "dependency": "transitive",
       "description": {
         "name": "built_value",
-        "sha256": "c9aabae0718ec394e5bc3c7272e6bb0dc0b32201a08fe185ec1d8401d3e39309",
+        "sha256": "fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.8.1"
+      "version": "8.9.1"
     },
     "change": {
       "dependency": "transitive",
       "description": {
         "name": "change",
-        "sha256": "75b6e28073433946a987e6082d00f08676a8260a6aa68cac8594c10611e7e9b9",
+        "sha256": "c92878d5d4f4960bda62201b5cae63f5d0aaaefc0377e856251920418070b96f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.2"
+      "version": "0.7.3"
     },
     "characters": {
       "dependency": "transitive",
@@ -174,11 +174,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "cider",
-        "sha256": "918ded9f4473d8042247b9e66a90101eb5ff72935c31df5d511a55f14e085ef0",
+        "sha256": "252b8ab6b05b4696fc970f2121cad64847d5c8b80f474fb31df3ba83d8edb706",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.4"
+      "version": "0.2.7"
     },
     "cli_util": {
       "dependency": "transitive",
@@ -204,11 +204,11 @@
       "dependency": "transitive",
       "description": {
         "name": "code_builder",
-        "sha256": "feee43a5c05e7b3199bb375a86430b8ada1b04104f2923d0e03cc01ca87b6d84",
+        "sha256": "f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.9.0"
+      "version": "4.10.0"
     },
     "collection": {
       "dependency": "direct main",
@@ -274,21 +274,21 @@
       "dependency": "transitive",
       "description": {
         "name": "dart_style",
-        "sha256": "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368",
+        "sha256": "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.4"
+      "version": "2.3.6"
     },
     "dio": {
       "dependency": "transitive",
       "description": {
         "name": "dio",
-        "sha256": "797e1e341c3dd2f69f2dad42564a6feff3bfb87187d05abb93b9609e6f1645c3",
+        "sha256": "49af28382aefc53562459104f64d16b9dfd1e8ef68c862d5af436cc8356ce5a8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.4.0"
+      "version": "5.4.1"
     },
     "equatable": {
       "dependency": "transitive",
@@ -334,31 +334,31 @@
       "dependency": "direct main",
       "description": {
         "name": "file_selector",
-        "sha256": "84eaf3e034d647859167d1f01cfe7b6352488f34c1b4932635012b202014c25b",
+        "sha256": "5019692b593455127794d5718304ff1ae15447dea286cdda9f0db2a796a1b828",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.1"
+      "version": "1.0.3"
     },
     "file_selector_android": {
       "dependency": "transitive",
       "description": {
         "name": "file_selector_android",
-        "sha256": "b7556052dbcc25ef88f6eba45ab98aa5600382af8dfdabc9d644a93d97b7be7f",
+        "sha256": "1cd66575f063b689e041aec836905ba7be18d76c9f0634d0d75daec825f67095",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.0+4"
+      "version": "0.5.0+7"
     },
     "file_selector_ios": {
       "dependency": "transitive",
       "description": {
         "name": "file_selector_ios",
-        "sha256": "2f48db7e338b2255101c35c604b7ca5ab588dce032db7fc418a2fe5f28da63f8",
+        "sha256": "b015154e6d9fddbc4d08916794df170b44531798c8dd709a026df162d07ad81d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.1+7"
+      "version": "0.5.1+8"
     },
     "file_selector_linux": {
       "dependency": "transitive",
@@ -384,11 +384,11 @@
       "dependency": "transitive",
       "description": {
         "name": "file_selector_platform_interface",
-        "sha256": "0aa47a725c346825a2bd396343ce63ac00bda6eff2fbc43eabe99737dede8262",
+        "sha256": "a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.1"
+      "version": "2.6.2"
     },
     "file_selector_web": {
       "dependency": "transitive",
@@ -440,11 +440,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_animate",
-        "sha256": "1dbc1aabfb8ec1e9d9feed2b675c21fb6b0a11f99be53ec3bc0f1901af6a8eb7",
+        "sha256": "7c8a6594a9252dad30cc2ef16e33270b6248c4dedc3b3d06c86c4f3f4dc05ae5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.3.0"
+      "version": "4.5.0"
     },
     "flutter_colorpicker": {
       "dependency": "direct main",
@@ -465,6 +465,16 @@
       },
       "source": "hosted",
       "version": "3.0.1"
+    },
+    "flutter_shaders": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_shaders",
+        "sha256": "02750b545c01ff4d8e9bbe8f27a7731aa3778402506c67daa1de7f5fc3f4befe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
     },
     "flutter_test": {
       "dependency": "direct dev",
@@ -512,21 +522,21 @@
       "dependency": "transitive",
       "description": {
         "name": "get_it",
-        "sha256": "f79870884de16d689cf9a7d15eedf31ed61d750e813c538a6efb92660fea83c3",
+        "sha256": "e6017ce7fdeaf218dc51a100344d8cb70134b80e28b760f8bb23c242437bafd7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.6.4"
+      "version": "7.6.7"
     },
     "github": {
       "dependency": "direct main",
       "description": {
         "name": "github",
-        "sha256": "45d7ffc34f4958b8f9910175e10fc00f976ad0b44ca5ee06fcfd7269a2dbb77f",
+        "sha256": "57f6ad78591f9638e903409977443093f862d25062a6b582a3c89e4ae44e4814",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.20.0"
+      "version": "9.24.0"
     },
     "glob": {
       "dependency": "transitive",
@@ -562,11 +572,11 @@
       "dependency": "direct main",
       "description": {
         "name": "http",
-        "sha256": "d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139",
+        "sha256": "a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     "http_multi_server": {
       "dependency": "transitive",
@@ -592,11 +602,11 @@
       "dependency": "transitive",
       "description": {
         "name": "image",
-        "sha256": "028f61960d56f26414eb616b48b04eb37d700cbe477b7fb09bf1d7ce57fd9271",
+        "sha256": "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.3"
+      "version": "4.1.7"
     },
     "image_size_getter": {
       "dependency": "direct main",
@@ -612,11 +622,11 @@
       "dependency": "transitive",
       "description": {
         "name": "intl",
-        "sha256": "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d",
+        "sha256": "d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.18.1"
+      "version": "0.19.0"
     },
     "io": {
       "dependency": "transitive",
@@ -632,11 +642,11 @@
       "dependency": "transitive",
       "description": {
         "name": "js",
-        "sha256": "f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3",
+        "sha256": "c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.6.7"
+      "version": "0.7.1"
     },
     "json_annotation": {
       "dependency": "transitive",
@@ -662,11 +672,11 @@
       "dependency": "direct main",
       "description": {
         "name": "logger",
-        "sha256": "6bbb9d6f7056729537a4309bda2e74e18e5d9f14302489cc1e93f33b3fe32cac",
+        "sha256": "b3ff55aeb08d9d8901b767650285872cb1bb8f508373b3e348d60268b0c7f770",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.2+1"
+      "version": "2.1.0"
     },
     "logging": {
       "dependency": "transitive",
@@ -702,11 +712,11 @@
       "dependency": "transitive",
       "description": {
         "name": "markdown",
-        "sha256": "acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd",
+        "sha256": "ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.1.1"
+      "version": "7.2.2"
     },
     "marker": {
       "dependency": "transitive",
@@ -762,11 +772,11 @@
       "dependency": "transitive",
       "description": {
         "name": "mime",
-        "sha256": "e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e",
+        "sha256": "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "mockito": {
       "dependency": "direct dev",
@@ -812,11 +822,11 @@
       "dependency": "direct main",
       "description": {
         "name": "nt4",
-        "sha256": "2d91e49059781d58c0701e731164acffa44de8ee6baf8dabb3b1925438b70346",
+        "sha256": "0dac7b51c3487970ad149a294a30fa1b5a8b668132e04855fdee260c87a30122",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     "package_config": {
       "dependency": "transitive",
@@ -862,11 +872,11 @@
       "dependency": "direct main",
       "description": {
         "name": "path_provider",
-        "sha256": "a1aa8aaa2542a6bc57e381f132af822420216c80d4781f7aa085ca3229208aaa",
+        "sha256": "b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "path_provider_android": {
       "dependency": "transitive",
@@ -882,11 +892,11 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_foundation",
-        "sha256": "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d",
+        "sha256": "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.1"
+      "version": "2.3.2"
     },
     "path_provider_linux": {
       "dependency": "transitive",
@@ -902,11 +912,11 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_platform_interface",
-        "sha256": "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c",
+        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "path_provider_windows": {
       "dependency": "transitive",
@@ -932,31 +942,31 @@
       "dependency": "transitive",
       "description": {
         "name": "platform",
-        "sha256": "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59",
+        "sha256": "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.3"
+      "version": "3.1.4"
     },
     "plugin_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "plugin_platform_interface",
-        "sha256": "f4f88d4a900933e7267e2b353594774fc0d07fb072b47eedcd5b54e1ea3269f8",
+        "sha256": "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.7"
+      "version": "2.1.8"
     },
     "pointycastle": {
       "dependency": "transitive",
       "description": {
         "name": "pointycastle",
-        "sha256": "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c",
+        "sha256": "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.7.3"
+      "version": "3.7.4"
     },
     "pool": {
       "dependency": "transitive",
@@ -1032,11 +1042,11 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_foundation",
-        "sha256": "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7",
+        "sha256": "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.4"
+      "version": "2.3.5"
     },
     "shared_preferences_linux": {
       "dependency": "transitive",
@@ -1052,11 +1062,11 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_platform_interface",
-        "sha256": "d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a",
+        "sha256": "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.1"
+      "version": "2.3.2"
     },
     "shared_preferences_web": {
       "dependency": "transitive",
@@ -1228,31 +1238,31 @@
       "dependency": "direct main",
       "description": {
         "name": "url_launcher",
-        "sha256": "e9aa5ea75c84cf46b3db4eea212523591211c3cf2e13099ee4ec147f54201c86",
+        "sha256": "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.2.2"
+      "version": "6.2.5"
     },
     "url_launcher_android": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "31222ffb0063171b526d3e569079cf1f8b294075ba323443fdc690842bfd4def",
+        "sha256": "d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.2.0"
+      "version": "6.3.0"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_ios",
-        "sha256": "bba3373219b7abb6b5e0d071b0fe66dfbe005d07517a68e38d4fc3638f35c6d3",
+        "sha256": "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.2.1"
+      "version": "6.2.5"
     },
     "url_launcher_linux": {
       "dependency": "transitive",
@@ -1278,21 +1288,21 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_platform_interface",
-        "sha256": "980e8d9af422f477be6948bdfb68df8433be71f5743a188968b0c1b887807e50",
+        "sha256": "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.0"
+      "version": "2.3.2"
     },
     "url_launcher_web": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_web",
-        "sha256": "7286aec002c8feecc338cc33269e96b73955ab227456e9fb2a91f7fab8a358e9",
+        "sha256": "fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.2"
+      "version": "2.2.3"
     },
     "url_launcher_windows": {
       "dependency": "transitive",
@@ -1328,11 +1338,11 @@
       "dependency": "transitive",
       "description": {
         "name": "version_manipulation",
-        "sha256": "9ef166939794d5bd80309cc6dbfe33c9f81674ba1c73ac117a866fd2dc746846",
+        "sha256": "e90782d610bde19765d2808ec06bc8ed9e04640a4dd07d1a3d370728ce9dae7f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     "visibility_detector": {
       "dependency": "direct main",
@@ -1378,31 +1388,31 @@
       "dependency": "transitive",
       "description": {
         "name": "win32",
-        "sha256": "b0f37db61ba2f2e9b7a78a1caece0052564d1bc70668156cf3a29d676fe4e574",
+        "sha256": "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.1.1"
+      "version": "5.2.0"
     },
     "window_manager": {
       "dependency": "direct main",
       "description": {
         "name": "window_manager",
-        "sha256": "dcc865277f26a7dad263a47d0e405d77e21f12cb71f30333a52710a408690bd7",
+        "sha256": "b3c895bdf936c77b83c5254bec2e6b3f066710c1f89c38b20b8acc382b525494",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.7"
+      "version": "0.3.8"
     },
     "xdg_directories": {
       "dependency": "transitive",
       "description": {
         "name": "xdg_directories",
-        "sha256": "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2",
+        "sha256": "faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.3"
+      "version": "1.0.4"
     },
     "xml": {
       "dependency": "transitive",
@@ -1426,7 +1436,7 @@
     }
   },
   "sdks": {
-    "dart": ">=3.2.0 <4.0.0",
-    "flutter": ">=3.16.0"
+    "dart": ">=3.2.3 <4.0.0",
+    "flutter": ">=3.16.6"
   }
 }


### PR DESCRIPTION
Update PathPlanner from 2024.1.4 to 2024.1.7. This is pretty much equivalent to what I have in my own repo [here](https://gitlab.com/ArchB1W/nix-dotfiles/-/blob/main/pkgs/frc/pathplanner/default.nix).

This has some changes from yours (aside from just the version number):
* Patch `pubspec.yaml` so that the version shown in the GUI is that of the package and not just `0.0.0`
* Use the `copyDesktopItems` hook instead of using the `install` command in `postInstall`
* Update desktop entry & `meta` description to be that of the Github repo and add `categories` and `keywords` to the desktop entry
* Replace `util-linux.lib` with just `libuuid`
* Add explicit `mainProgram` field

One thing to note is that I seem to get a crash whenever I open up a selector (such as picking a Named Command). I think this is an upstream issue? This crash also happens for me `2024.1.4` with both your current package and mine, so I'm not sure who's at fault.