### PR TITLE
advantagescope: 3.2.0 -> 3.2.1

### DIFF
--- a/pkgs/advantagescope/default.nix
+++ b/pkgs/advantagescope/default.nix
@@ -1,46 +1,44 @@
-{ lib, stdenv, fetchurl, appimageTools, makeDesktopItem }:
+{ lib, stdenv, fetchurl, appimageTools }:
 
 let
   pname = "advantagescope";
-  version = "3.2.0";
+  version = "3.2.1";
 
-  desktopItem = makeDesktopItem {
-    type = "Application";
-    name = "AdvantageScope";
-    desktopName = "AdvantageScope";
-    comment = "Robot telemetry viewer for FIRST Robotics Competition teams";
-    icon = "advantagescope";
-    exec = "advantagescope %u";
-  };
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-x64-v${version}.AppImage";
+      hash = "sha256-s9JcUApkAa5V5AYT+4ZqlvsiB0b/P3rptTDHo160P3U=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-arm64-v${version}.AppImage";
+      hash = "sha256-MgPCiOv8Fpvlg8V8H+3Oe+IpyY6jwi6W49yLzwmSeKI=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   icon = fetchurl {
     url = "https://raw.githubusercontent.com/Mechanical-Advantage/AdvantageScope/v${version}/icons/window-icon.png";
     hash = "sha256-gqcCqthqM2g4sylg9zictKwRggbaALQk9ln/NaFHxdY=";
   };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
 in
 appimageTools.wrapType2 {
-  inherit pname version;
-
-  src = {
-    x86_64-linux = fetchurl {
-      url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-x64-v${version}.AppImage";
-      hash = "sha256-VLHcJVRYdAf1TEGmKvSJKauJwnUvHNG67WhX1rj8rKk=";
-    };
-
-    aarch64-linux = fetchurl {
-      url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-arm64-v${version}.AppImage";
-      hash = "sha256-FAhJr8PFDhkR03WWT/FvIAJhrnR2tcBWCv8NqrPL7oM=";
-    };
-  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  inherit pname version src;
 
   extraInstallCommands = ''
     mv $out/bin/${pname}-${version} $out/bin/${pname}
-    install -D "${desktopItem}/share/applications/"* -t $out/share/applications/
-    install -D ${icon} $out/share/pixmaps/advantagescope.png
+    install -Dm 444 ${appimageContents}/${pname}.desktop "$out"/share/applications/${pname}.desktop
+    install -Dm 444 ${icon} "$out"/share/pixmaps/advantagescope.png
+
+    substituteInPlace "$out"/share/applications/${pname}.desktop \
+      --replace "Exec=AppRun" "Exec=${pname}"
   '';
 
   meta = with lib; {
-    description = "Robot telemetry viewer for FIRST Robotics Competition teams";
+    description = "AdvantageScope is a robot diagnostics, log review/analysis, and data visualization application for FIRST Robotics Competition teams";
     homepage = "https://github.com/Mechanical-Advantage/AdvantageScope";
     license = licenses.mit;
     mainProgram = "advantagescope";


### PR DESCRIPTION
Updates `advantagescope` to 3.2.1 and a couple other minor changes:
* Update description to what I saw in AdvantageScope's repo
* Use the `.desktop` file present in the AppImage instead of rolling our own and just do a small patch to fix the `Exec=` field